### PR TITLE
feat: make it runnable with buildFHSEnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+watch_file flake.lock
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.direnv
 result
+xml_converter

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ ldd ./burrito.x86_64
 to solve this, as I understand it, I need to use `makeWrapper` in `nativeBuildInputs`, and then provide all packages in `pkgs.lib.makeBinPath (with pkgs; [ xorg.libX11 ])`
 
 burrito repo is now working on automated github workflows to create a CI system, so I can have a sneak peek at the build process when they will finish it, because now I can't find any clues from the repo inself. I don't know how godot projects works in this regard.
+
+
+# Additional note
+
+Running `nix develop` (or having a direnv active) allows to run `burrito-gw2` directly, however it doesn't quite work because burrito invokes `./xml_converter`, a fix is to copy this to the current folder.
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ to solve this, as I understand it, I need to use `makeWrapper` in `nativeBuildIn
 burrito repo is now working on automated github workflows to create a CI system, so I can have a sneak peek at the build process when they will finish it, because now I can't find any clues from the repo inself. I don't know how godot projects works in this regard.
 
 
-# Additional note
 
-Running `nix develop` (or having a direnv active) allows to run `burrito-gw2` directly, however it doesn't quite work because burrito invokes `./xml_converter`, a fix is to copy this to the current folder.
+# Additional notes
+
+Running `nix develop` (or using direnv) allows to run `burrito-gw2`, however it doesn't quite work in stand-alone because burrito invokes `./xml_converter`, a fix is to copy this file (found in burrito release) to the current folder.
+
+It currently involves building a FHS env to satisfy burrito dependencies.
+
+I'll explore building from sources from within Nix.
+
+Also I'm planning to try and add some config options like the GW2 path so the .dll could be symlinked in it.
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,16 +33,7 @@
         libudev-zero
       ];
 
-      runScript = "${src}/burrito.x86_64";
-
-      # dummy
-      # to see whats I'm getting
-      #installPhase = ''
-      #  mkdir -p $out/bin
-      #  cp -r $src $out/bin
-      #  cp $src/burrito.x86_64 $out/bin/burrito-gw2
-      #  chmod +x $out/bin/burrito-gw2
-      #'';
+      runScript = "${self}/script.sh ${src}";
     };
 
     devShell.${system} = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -5,16 +5,17 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, ... }: 
-  let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
-    src = pkgs.fetchzip {
-      url = "https://github.com/AsherGlick/Burrito/releases/download/burrito-1.0.0/burrito-1.0.0.zip";
-      stripRoot = false;
-      sha256 = "10iz1w3vz1881i8h898v2ankhfhcsi439jh8b38z14jpfzbv2m6x";
-    }; 
-    deps = with pkgs; [
+  outputs =
+    { self, nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      src = pkgs.fetchzip {
+        url = "https://github.com/AsherGlick/Burrito/releases/download/burrito-1.0.0/burrito-1.0.0.zip";
+        stripRoot = false;
+        sha256 = "10iz1w3vz1881i8h898v2ankhfhcsi439jh8b38z14jpfzbv2m6x";
+      };
+      deps = with pkgs; [
         stdenv.cc.cc.lib
         glibc
         gcc
@@ -27,54 +28,88 @@
         xorg.libXi
         libGL
         libudev-zero
-    ];
-  in 
-  {
-    packages.${system} = {
-      default = self.packages.${system}.burrito;
+      ];
+    in
+    {
+      packages.${system} = {
+        burrito-fhs = pkgs.buildFHSUserEnv {
+          name = "burrito-gw2";
 
-      burrito = pkgs.stdenv.mkDerivation {
-        name = "burrito";
-        version = "1.0.0";
-        src = src;
-        nativeBuildInputs = [ pkgs.makeWrapper pkgs.autoPatchelfHook ];
-        buildInputs = deps;
-        runtimeDependencies = deps;
-        installPhase = ''
-          mkdir -p $out/bin $out/lib
+          targetPkgs =
+            pkgs: with pkgs; [
+              glibc
+              xorg.libXcursor
+              xorg.libX11
+              xorg.libXinerama
+              xorg.libXext
+              xorg.libXrandr
+              xorg.libXrender
+              xorg.libXi
+              libGL
+              libudev-zero
+            ];
 
-          # Copy the main executable
-          cp $src/burrito.x86_64 $out/bin/burrito.x86_64
-          chmod +x $out/bin/burrito.x86_64
+          runScript = "${self}/script.sh ${src}";
+        };
 
-          # Copy the xml_converter
-          cp $src/xml_converter $out/bin/xml_converter
-          chmod +x $out/bin/xml_converter
+        default = self.packages.${system}.burrito;
 
-          # Copy the libraries
-          cp $src/*.so $out/lib/
-     
-          # Patch the binary
-          # chmod +w $out/bin/burrito.x86_64
-          # patchelf --set-rpath "$out/lib:${pkgs.lib.makeLibraryPath deps}" $out/bin/burrito.x86_64
-          # chmod -w $out/bin/burrito.x86_64
+        burrito = pkgs.stdenv.mkDerivation {
+          name = "burrito";
+          version = "1.0.0";
+          src = src;
+          nativeBuildInputs = [
+            pkgs.makeWrapper
+            # pkgs.autoPatchelfHook
+          ];
+          buildInputs = deps;
+          # runtimeDependencies = deps;
 
-          # Create a wrapper script
-          makeWrapper $out/bin/burrito.x86_64 $out/bin/burrito \
-              --set LD_LIBRARY_PATH "$out/lib:${pkgs.lib.makeLibraryPath deps}" \
-              --chdir "$out/bin"
-        '';
-        meta = {
+          # '' = {
           description = "Burrito Guild Wars 2 overlay";
           platforms = [ "x86_64-linux" ];
+
+          installPhase = ''
+            mkdir -p $out/bin $out/lib
+
+            # Copy the main executable
+            cp $src/burrito.x86_64 $out/bin/burrito.x86_64
+            chmod +x $out/bin/burrito.x86_64
+
+            # Copy the xml_converter
+            cp $src/xml_converter $out/bin/xml_converter
+            chmod +x $out/bin/xml_converter
+
+            # Copy the libraries
+            cp $src/*.so $out/lib/
+
+            # Patch the binary
+            # chmod +w $out/bin/burrito.x86_64
+            # patchelf --set-rpath "$out/lib:$ {pkgs.lib.makeLibraryPath deps}" $out/bin/burrito.x86_64
+            # chmod -w $out/bin/burrito.x86_64
+
+            # Create a wrapper script
+            # makeWrapper $out/bin/burrito.x86_64 $out/bin/burrito \
+            #     --set LD_LIBRARY_PATH "$out/lib:$ {pkgs.lib.makeLibraryPath deps}" \
+            #     --chdir "$out/bin"
+
+            # Create a wrapper
+            cat > $out/bin/burrito << EOF
+            #!/bin/sh
+            cd $out/bin
+            export LD_LIBRARY_PATH="$out/lib:${pkgs.lib.makeLibraryPath deps}"
+            exec ./burrito.x86_64 "\$@"
+            EOF
+
+            chmod +x $out/bin/burrito
+          '';
         };
       };
-    };
 
-    devShell.${system} = pkgs.mkShell {
-      buildInputs = [
-        self.packages.${system}.default
-      ];
+      devShell.${system} = pkgs.mkShell {
+        buildInputs = [
+          self.packages.${system}.burrito-fhs
+        ];
+      };
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,15 +13,11 @@
       url = "https://github.com/AsherGlick/Burrito/releases/download/burrito-1.0.0/burrito-1.0.0.zip";
       stripRoot = false;
       sha256 = "10iz1w3vz1881i8h898v2ankhfhcsi439jh8b38z14jpfzbv2m6x";
-    };
-  in 
-  {
-
-    packages.${system}.default = pkgs.buildFHSUserEnv {
-      name = "burrito-gw2";
-
-      targetPkgs = pkgs: with pkgs; [
+    }; 
+    deps = with pkgs; [
+        stdenv.cc.cc.lib
         glibc
+        gcc
         xorg.libXcursor
         xorg.libX11
         xorg.libXinerama
@@ -31,9 +27,48 @@
         xorg.libXi
         libGL
         libudev-zero
-      ];
+    ];
+  in 
+  {
+    packages.${system} = {
+      default = self.packages.${system}.burrito;
 
-      runScript = "${self}/script.sh ${src}";
+      burrito = pkgs.stdenv.mkDerivation {
+        name = "burrito";
+        version = "1.0.0";
+        src = src;
+        nativeBuildInputs = [ pkgs.makeWrapper pkgs.autoPatchelfHook ];
+        buildInputs = deps;
+        runtimeDependencies = deps;
+        installPhase = ''
+          mkdir -p $out/bin $out/lib
+
+          # Copy the main executable
+          cp $src/burrito.x86_64 $out/bin/burrito.x86_64
+          chmod +x $out/bin/burrito.x86_64
+
+          # Copy the xml_converter
+          cp $src/xml_converter $out/bin/xml_converter
+          chmod +x $out/bin/xml_converter
+
+          # Copy the libraries
+          cp $src/*.so $out/lib/
+     
+          # Patch the binary
+          # chmod +w $out/bin/burrito.x86_64
+          # patchelf --set-rpath "$out/lib:${pkgs.lib.makeLibraryPath deps}" $out/bin/burrito.x86_64
+          # chmod -w $out/bin/burrito.x86_64
+
+          # Create a wrapper script
+          makeWrapper $out/bin/burrito.x86_64 $out/bin/burrito \
+              --set LD_LIBRARY_PATH "$out/lib:${pkgs.lib.makeLibraryPath deps}" \
+              --chdir "$out/bin"
+        '';
+        meta = {
+          description = "Burrito Guild Wars 2 overlay";
+          platforms = [ "x86_64-linux" ];
+        };
+      };
     };
 
     devShell.${system} = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -9,42 +9,46 @@
   let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
+    src = pkgs.fetchzip {
+      url = "https://github.com/AsherGlick/Burrito/releases/download/burrito-1.0.0/burrito-1.0.0.zip";
+      stripRoot = false;
+      sha256 = "10iz1w3vz1881i8h898v2ankhfhcsi439jh8b38z14jpfzbv2m6x";
+    };
   in 
   {
 
-    packages.${system}.default = pkgs.stdenv.mkDerivation {
+    packages.${system}.default = pkgs.buildFHSUserEnv {
       name = "burrito-gw2";
 
-      buildInputs = with pkgs; [
+      targetPkgs = pkgs: with pkgs; [
+        glibc
+        xorg.libXcursor
+        xorg.libX11
+        xorg.libXinerama
+        xorg.libXext
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libXi
+        libGL
+        libudev-zero
       ];
 
-      # will fetch github source code
-      # src = pkgs.fetchFromGitHub {
-      #   owner = "AsherGlick";
-      #   repo = "Burrito";
-      #   # to find out rev view tags on github
-      #   # also can check yourself with
-      #   # https://github.com/AsherGlick/Burrito/archive/refs/tags/alpha-1.4.zip
-      #   rev = "alpha-1.4";
-      #   # to find sha256
-      #   # nix-prefetch-url --unpack https://github.com/AsherGlick/Burrito/archive/refs/tags/alpha-1.4.zip --type sha256
-      #   sha256 = "164wjr7y339s67fk1b3kyz4jdx0j64qx77mkzz09wdizi7idphf3";
-      # };
-      src = pkgs.fetchzip {
-        url = "https://github.com/AsherGlick/Burrito/releases/download/alpha-1.4/Burrito_Linux.zip";
-        # because zip don't have a root directory
-        stripRoot=false;
-        # nix-prefetch-url --unpack <url> --type sha256
-        sha256 = "0a9f8dby8b3pn36nz0plf2kyjijlr0f6zc7vb8ym044ivrq97ss9";
-      };
+      runScript = "${src}/burrito.x86_64";
 
       # dummy
       # to see whats I'm getting
-      installPhase = ''
-        mkdir -p $out/bin
-        cp -r $src $out/bin
-      '';
+      #installPhase = ''
+      #  mkdir -p $out/bin
+      #  cp -r $src $out/bin
+      #  cp $src/burrito.x86_64 $out/bin/burrito-gw2
+      #  chmod +x $out/bin/burrito-gw2
+      #'';
     };
 
+    devShell.${system} = pkgs.mkShell {
+      buildInputs = [
+        self.packages.${system}.default
+      ];
+    };
   };
 }

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd $1
+./burrito.x86_64


### PR DESCRIPTION
Hello @lumpsoid,

Just a small contribution to try and make it work. I am running NixOS but by no means am an expert.

There are still some caveats I've written in the README.

I guess for now this is still a draft / work in progress as there might be some low hanging fruits I'll try to fix in that PR.

Main issue is the need for a relative `./xml_converter` because of a call from burrito during runtime.
I'm not sure if the project allows for a way to specify its path (i.e env variable -> [seems not](https://github.com/AsherGlick/Burrito/blob/e4cc14744905f3678a1c7460452f70df7de1acb7/FileHandler.gd#L3)), or if it could work with patchelf or something.